### PR TITLE
No content result

### DIFF
--- a/ServiceResult.NuGet/ServiceResult.NuGet.nuproj
+++ b/ServiceResult.NuGet/ServiceResult.NuGet.nuproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{1982C97A-D38F-4C97-A3EF-922DD1257F04}</ProjectGuid>
     <Description>Result models for the service result pattern. Allows for wrapping data and errors in a reusable way.</Description>
     <PackageId>ServiceResult</PackageId>
-    <PackageVersion>1.0.1</PackageVersion>
+    <PackageVersion>1.0.2</PackageVersion>
     <Authors>SuavePirate</Authors>
     <DevelopmentDependency>false</DevelopmentDependency>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/ServiceResult/NoContentResult.cs
+++ b/ServiceResult/NoContentResult.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+
+namespace ServiceResult
+{
+    /// <summary>
+    /// No content result.
+    /// </summary>
+    public class NoContentResult : Result<object>
+    {
+        public NoContentResult()
+        {
+        }
+
+        public override ResultType ResultType => ResultType.NoContent;
+
+        public override List<string> Errors => new List<string>();
+
+        public override object Data => default(object);
+    }
+}

--- a/ServiceResult/ResultType.cs
+++ b/ServiceResult/ResultType.cs
@@ -3,6 +3,7 @@
     public enum ResultType
     {
         Ok,
+        NoContent,
         Unexpected,
         NotFound,
         Unauthorized,


### PR DESCRIPTION
Added a NoContent result. This will allow for a more explicit definition of a success without any data.