### PR TITLE
No content result extension

### DIFF
--- a/ServiceResult.ApiExtensions.NuGet/ServiceResult.ApiExtensions.NuGet.nuproj
+++ b/ServiceResult.ApiExtensions.NuGet/ServiceResult.ApiExtensions.NuGet.nuproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{5EACDADD-1D3C-436B-BCC8-0DEA4994C30E}</ProjectGuid>
     <Description>ServiceResult API Extensions to create action results from service results</Description>
     <PackageId>ServiceResult.ApiExtensions</PackageId>
-    <PackageVersion>1.0.1</PackageVersion>
+    <PackageVersion>1.0.2</PackageVersion>
     <Authors>SauvePirate</Authors>
     <DevelopmentDependency>false</DevelopmentDependency>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/ServiceResult.ApiExtensions/ResultExtensions.cs
+++ b/ServiceResult.ApiExtensions/ResultExtensions.cs
@@ -20,6 +20,8 @@ namespace ServiceResult.ApiExtensions
             {
                 case ResultType.Ok:
                     return controller.Ok(result.Data);
+                case ResultType.NoContent:
+                    return controller.NoContent();
                 case ResultType.NotFound:
                     return controller.NotFound(result.Errors);
                 case ResultType.Invalid:

--- a/ServiceResult.ApiExtensions/ServiceResult.ApiExtensions.csproj
+++ b/ServiceResult.ApiExtensions/ServiceResult.ApiExtensions.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ServiceResult" Version="1.0.1" />
+    <PackageReference Include="ServiceResult" Version="1.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.0.0" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
   </ItemGroup>


### PR DESCRIPTION
Added a NoContent result. This will allow for a more explicit definition of a success without any data.