### PR TITLE
Sintactic sugar for result validation (implicit conversion to bool)

### DIFF
--- a/ServiceResult/Result.cs
+++ b/ServiceResult/Result.cs
@@ -11,5 +11,10 @@ namespace ServiceResult
         public abstract ResultType ResultType { get; }
         public abstract List<string> Errors { get; }
         public abstract T Data { get; }
+
+        public static implicit operator bool(Result<T> result)
+        {
+            return result.ResultType == ResultType.Ok;
+        }
     }
 }


### PR DESCRIPTION
On numerous occasions, we make use of the Result resource after a service call in a way similar to the following:

```csharp
if (result.ResultType != ResultType.Ok)
{
    //Handle error case
}

```
We have considered it appropriate to add an implicit conversion from Result type to bool as a form of syntactic sugar, so that it can be easily checked as follows:

```csharp
if (!result)
{
    //Handle error case
}
```