### PR TITLE
Allow error list handling for result remapping coherence

### DIFF
--- a/ServiceResult/InvalidResult.cs
+++ b/ServiceResult/InvalidResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ServiceResult
 {
@@ -8,14 +9,25 @@ namespace ServiceResult
     /// </summary>
     public class InvalidResult<T> : Result<T>
     {
-        private string _error;
+        private List<string> _errors;
         public InvalidResult(string error)
         {
-            _error = error;
+            _errors = new List<string>();
+
+            if (!string.IsNullOrEmpty(error))
+            { 
+                _errors.Add(error);
+            }
         }
+
+        public InvalidResult(List<string> errors)
+        { 
+            _errors = errors;
+        }
+
         public override ResultType ResultType => ResultType.Invalid;
 
-        public override List<string> Errors => new List<string> { _error ?? "The input was invalid." };
+        public override List<string> Errors => (_errors != null && _errors.Any()) ? _errors : new List<string> { "The input was invalid." };
 
         public override T Data => default(T);
     }

--- a/ServiceResult/NotFoundResult.cs
+++ b/ServiceResult/NotFoundResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ServiceResult
 {
@@ -8,14 +9,25 @@ namespace ServiceResult
     /// </summary>
     public class NotFoundResult<T> : Result<T>
     {
-        private readonly string _error;
+        private List<string> _errors;
         public NotFoundResult(string error)
         {
-            _error = error;
+            _errors = new List<string>();
+
+            if (!string.IsNullOrEmpty(error))
+            {
+                _errors.Add(error);
+            }
         }
+
+        public NotFoundResult(List<string> errors)
+        {
+            _errors = errors;
+        }
+
         public override ResultType ResultType => ResultType.NotFound;
 
-        public override List<string> Errors => new List<string> { _error ?? "The entity you're looking for cannot be found" };
+        public override List<string> Errors => (_errors != null && _errors.Any()) ? _errors : new List<string> { "The entity you're looking for cannot be found." };
 
         public override T Data => default(T);
     }

--- a/ServiceResult/UnexpectedResult.cs
+++ b/ServiceResult/UnexpectedResult.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace ServiceResult
 {
@@ -8,19 +9,30 @@ namespace ServiceResult
     /// </summary>
     public class UnexpectedResult<T> : Result<T>
     {
-
-        private readonly string _error;
+        private List<string> _errors;
         public UnexpectedResult(string error)
         {
-            _error = error;
+            _errors = new List<string>();
+
+            if (!string.IsNullOrEmpty(error))
+            {
+                _errors.Add(error);
+            }
         }
+
+        public UnexpectedResult(List<string> errors)
+        {
+            _errors = errors;
+        }
+
         public UnexpectedResult()
         {
 
         }
+
         public override ResultType ResultType => ResultType.Unexpected;
 
-        public override List<string> Errors => new List<string> { _error ?? "There was an unexpected problem" };
+        public override List<string> Errors => (_errors != null && _errors.Any()) ? _errors : new List<string> { "There was an unexpected problem." };
 
         public override T Data => default(T);
     }


### PR DESCRIPTION
It's common that within the same service there are methods that make use of the functionality of Result<T> with different T within the same service, and these are used within a main method that makes calls to various private methods of the service.

When trying to return a Result<T> of a different type from the main method, there is a possibility that one might want to add the error list of various Result<T> that have been collected to the main Result<T> of the method. However, there is no constructor that accepts a list as an input parameter. Nevertheless, the Errors type is a list, which makes it difficult to remap the results.